### PR TITLE
k6 addition to the radar

### DIFF
--- a/radar/tools.js
+++ b/radar/tools.js
@@ -234,6 +234,48 @@ const content = [
 </p>
 `,
   },
+  {
+    name: 'K6',
+    ring: 'trial',
+    quadrant: 'Tools',
+    isNew: 'False',
+    status: 'FALSE',
+    description: `
+<H4>Description:</H4>
+<p>K6 is an open-source performance testing tool designed for modern developers and DevOps teams.
+Built with a focus on load testing, K6 enables users to write tests in JavaScript and execute them efficiently at scale.
+It is particularly well-suited for testing APIs, microservices, and web applications, offering smooth integration with CI/CD pipelines.
+K6 is scriptable, lightweight, and can be run locally or in the cloud.</p>
+<H4>Pros</h4>
+<ul>
+  <li>
+    <strong>Developer-friendly:</strong> Written in JavaScript, making it easy for developers to script and maintain tests.
+  </li>
+  <li>
+    <strong>High performance:</strong> Efficiently handles large-scale load tests with minimal resource consumption.
+  </li>
+  <li>
+    <strong>CI/CD Integration:</strong> Works seamlessly with modern CI/CD workflows for automated performance testing.
+  </li>
+    <li>
+    <strong>Detailed Metrics:</strong> Provides in-depth insights into response times, request rates, and system behavior under load.
+  </li>
+    <li>
+    <strong>Open-source:</strong> Free to use, with an active community contributing to improvements and new features.
+  </li>
+</ul>
+<H4>Cons</h4>
+<ul>
+  <li>
+    <strong>UI:</strong> K6 provides a user interface with Grafana K6 Studio. Currently, this is under public preview. Making K6 more suitable for an audience with a development background.
+  </li>
+</ul>
+<h4>Conclusion:</h4>
+<p>K6 is a powerful and efficient tool for load testing, particularly for teams looking to integrate performance testing into their CI/CD pipelines.
+While it lacks a UI and built-in functional testing features, its scripting capabilities and high performance make it an excellent choice for developers focused on API and application performance.
+For organizations needing extensive protocol support or non-technical users, alternative solutions like JMeter might be more suitable.</p>
+`,
+  },
 ]
 
 exports.tools = {

--- a/radar/tools.js
+++ b/radar/tools.js
@@ -277,8 +277,8 @@ k6 is scriptable, lightweight, and can be run locally or in the cloud.</p>
 </ul>
 <h4>Conclusion:</h4>
 <p>k6 is a powerful and efficient tool for load testing, particularly for teams looking to integrate performance testing into their CI/CD pipelines.
-While it lacks a UI and built-in functional testing features, its scripting capabilities and high performance make it an excellent choice for developers focused on API and application performance.
-For organizations needing extensive protocol support or non-technical users, alternative solutions like JMeter might be more suitable.</p>
+While it lacks a detailed and mature UI and built-in functional testing features, its scripting capabilities and high performance make it an excellent choice for developers focused on API and application performance.
+</p>
 `,
   },
 ]

--- a/radar/tools.js
+++ b/radar/tools.js
@@ -235,30 +235,30 @@ const content = [
 `,
   },
   {
-    name: 'K6',
+    name: 'k6',
     ring: 'trial',
     quadrant: 'Tools',
     isNew: 'False',
     status: 'FALSE',
     description: `
 <H4>Description:</H4>
-<p>K6 is an open-source performance testing tool designed for modern developers and DevOps teams.
-Built with a focus on load testing, K6 enables users to write tests in JavaScript and execute them efficiently at scale.
+<p>k6 is an open-source performance testing tool designed for modern developers and DevOps teams.
+Built with a focus on load testing, k6 enables users to write tests in JavaScript and execute them efficiently at scale.
 It is particularly well-suited for testing APIs, microservices, and web applications, offering smooth integration with CI/CD pipelines.
-K6 is scriptable, lightweight, and can be run locally or in the cloud.</p>
+k6 is scriptable, lightweight, and can be run locally or in the cloud.</p>
 <H4>Pros</h4>
 <ul>
   <li>
     <strong>Developer-friendly:</strong> Written in JavaScript, making it easy for developers to script and maintain tests.
   </li>
   <li>
-    <strong>High performance:</strong> Efficiently handles large-scale load tests with minimal resource consumption.
+    <strong>High performance:</strong> Efficiently handles large-scale load tests with low resource consumption.
   </li>
   <li>
-    <strong>CI/CD Integration:</strong> Works seamlessly with modern CI/CD workflows for automated performance testing.
+    <strong>CI/CD Integration:</strong> Works with modern CI/CD workflows for automated performance testing.
   </li>
     <li>
-    <strong>Detailed Metrics:</strong> Provides in-depth insights into response times, request rates, and system behavior under load.
+    <strong>Detailed Metrics:</strong> Provides detailed insights into response times, request rates, and system behavior under load.
   </li>
     <li>
     <strong>Open-source:</strong> Free to use, with an active community contributing to improvements and new features.
@@ -267,7 +267,12 @@ K6 is scriptable, lightweight, and can be run locally or in the cloud.</p>
 <H4>Cons</h4>
 <ul>
   <li>
-    <strong>UI:</strong> K6 provides a user interface with Grafana K6 Studio. Currently, this is under public preview. Making K6 more suitable for an audience with a development background.
+    <strong>UI:</strong> k6 provides a user interface with Grafana k6 Studio. Currently, this is under public preview.
+    Making k6 more suitable for an audience with a development background.
+  </li>
+    <li>
+    <strong>Grafana Cloud k6:</strong> Grafana Cloud k6 is a paid service that offers additional features like cloud execution and advanced analytics.
+    This means that for additional possibilities, you will have to pay.
   </li>
 </ul>
 <h4>Conclusion:</h4>

--- a/radar/tools.js
+++ b/radar/tools.js
@@ -243,36 +243,35 @@ const content = [
     description: `
 <H4>Description:</H4>
 <p>k6 is an open-source performance testing tool designed for modern developers and DevOps teams.
-Built with a focus on load testing, k6 enables users to write tests in JavaScript and execute them efficiently at scale.
+Built with a focus on load testing, k6 enables users to write tests in both JavaScript & Typescript since v0.57 and execute them efficiently at scale.
+Making k6 more suitable for an audience with a development background.
 It is particularly well-suited for testing APIs, microservices, and web applications, offering smooth integration with CI/CD pipelines.
-k6 is scriptable, lightweight, and can be run locally or in the cloud.</p>
+k6 is scriptable, lightweight, and can be run locally or in the cloud. k6 provides a user interface with Grafana k6 Studio. Currently, this is under public preview.
+Free to use, with an active community contributing to improvements and new features.</p>
 <H4>Pros</h4>
 <ul>
   <li>
-    <strong>Developer-friendly:</strong> Written in JavaScript, making it easy for developers to script and maintain tests.
+    <strong>Developer-friendly:</strong> Written in JavaScript/Typescript, making it easy for developers to script and maintain tests.
   </li>
   <li>
-    <strong>High performance:</strong> Efficiently handles large-scale load tests with low resource consumption.
+    <strong>Distributed testing:</strong> k6 allows for distributed testing, enabling users to run tests across multiple machines and simulate real-world scenarios.
+    Thus making it possible to test the scalability of your application.
   </li>
   <li>
-    <strong>CI/CD Integration:</strong> Works with modern CI/CD workflows for automated performance testing.
-  </li>
-    <li>
     <strong>Detailed Metrics:</strong> Provides detailed insights into response times, request rates, and system behavior under load.
-  </li>
-    <li>
-    <strong>Open-source:</strong> Free to use, with an active community contributing to improvements and new features.
   </li>
 </ul>
 <H4>Cons</h4>
 <ul>
-  <li>
-    <strong>UI:</strong> k6 provides a user interface with Grafana k6 Studio. Currently, this is under public preview.
-    Making k6 more suitable for an audience with a development background.
-  </li>
     <li>
     <strong>Grafana Cloud k6:</strong> Grafana Cloud k6 is a paid service that offers additional features like cloud execution and advanced analytics.
     This means that for additional possibilities, you will have to pay.
+  </li>
+  <li>
+    <strong>Not language agnostic:</strong> k6 is limited to JavaScript/Typescript, which may not be ideal for teams using or being familiar with other languages.
+  </li>
+  <li>
+    <strong>Learning Curve:</strong> While k6 is developer-friendly, users might face a learning curve if they are not familiar with performance testing.
   </li>
 </ul>
 <h4>Conclusion:</h4>

--- a/radar/tools.js
+++ b/radar/tools.js
@@ -276,7 +276,7 @@ k6 is scriptable, lightweight, and can be run locally or in the cloud.</p>
   </li>
 </ul>
 <h4>Conclusion:</h4>
-<p>K6 is a powerful and efficient tool for load testing, particularly for teams looking to integrate performance testing into their CI/CD pipelines.
+<p>k6 is a powerful and efficient tool for load testing, particularly for teams looking to integrate performance testing into their CI/CD pipelines.
 While it lacks a UI and built-in functional testing features, its scripting capabilities and high performance make it an excellent choice for developers focused on API and application performance.
 For organizations needing extensive protocol support or non-technical users, alternative solutions like JMeter might be more suitable.</p>
 `,


### PR DESCRIPTION
Added k6 to the tech radar. It is part of the tools section and currently placed under the category of "trial".

Please check if this is as intended and that the corresponding text of the description, pros and cons are in line with what it should be.