### PR TITLE
feat: add Playwright CLI and Playwright MCP blips

### DIFF
--- a/radar/content/tools/playwright-cli.html
+++ b/radar/content/tools/playwright-cli.html
@@ -25,8 +25,7 @@ status: "New"
     data accumulates, so decision quality stays consistent from start to finish.
   </li>
   <li>
-    <strong>Generates Playwright test code automatically:</strong> Browsing a flow produces reusable Playwright code,
-    making it a natural fit for agentic test writing workflows.
+    <strong>Works with any coding agent out of the box:</strong> Because <code>playwright-cli</code> is just shell commands, any agent that can run a terminal (Claude Code, GitHub Copilot, Cursor, Windsurf) can use it immediately with no MCP client configuration or protocol integration required.
   </li>
 </ul>
 

--- a/radar/content/tools/playwright-cli.html
+++ b/radar/content/tools/playwright-cli.html
@@ -1,0 +1,51 @@
+---
+name: "Playwright CLI"
+ring: "Trial"
+isNew: "TRUE"
+status: "New"
+---
+
+<h4>Description:</h4>
+<p>
+  Playwright CLI (<code>@playwright/cli</code>) is a command-line tool built specifically for AI coding agents.
+  Instead of streaming browser state into the model's context window like MCP does, it saves snapshots to disk as
+  YAML files. Agents issue shell commands like <code>open</code>, <code>click</code>, and <code>snapshot</code>,
+  and read results from disk on demand. Browsing a flow produces reusable Playwright test code as output, making
+  it a natural companion to Claude Code and the agentic test writing approach.
+</p>
+
+<h4>Pros:</h4>
+<ul>
+  <li>
+    <strong>4x lower token usage than MCP:</strong> Browser state stays on disk, not in the context window. This
+    directly affects cost and how long an agent can work before hitting context limits.
+  </li>
+  <li>
+    <strong>Clean context throughout the session:</strong> Each snapshot overwrites the previous one. No stale page
+    data accumulates, so decision quality stays consistent from start to finish.
+  </li>
+  <li>
+    <strong>Generates Playwright test code automatically:</strong> Browsing a flow produces reusable Playwright code,
+    making it a natural fit for agentic test writing workflows.
+  </li>
+</ul>
+
+<h4>Cons:</h4>
+<ul>
+  <li>
+    <strong>Requires filesystem and shell access:</strong> Does not work in sandboxed environments. A natural fit
+    for Claude Code, but incompatible with some setups.
+  </li>
+  <li>
+    <strong>Not plug-and-play with chat clients:</strong> No direct integration with Claude Desktop or VS Code
+    Copilot. It requires a coding agent with filesystem access.
+  </li>
+</ul>
+
+<h4>Conclusion:</h4>
+<p>
+  If you are still using Playwright MCP, now is a good time to switch. Playwright CLI gives you the same browser
+  control with a fraction of the token cost and none of the context pollution. We recommend starting with
+  Playwright CLI over MCP for any new AI-driven test automation work, especially if you are moving towards
+  a more agentic testing approach.
+</p>

--- a/radar/content/tools/playwright-cli.html
+++ b/radar/content/tools/playwright-cli.html
@@ -17,7 +17,7 @@ status: "New"
 <h4>Pros:</h4>
 <ul>
   <li>
-    <strong>4x lower token usage than MCP:</strong> Browser state stays on disk, not in the context window. This
+    <strong>Lower token usage than MCP:</strong> Browser state stays on disk, not in the context window. This
     directly affects cost and how long an agent can work before hitting context limits.
   </li>
   <li>

--- a/radar/content/tools/playwright-mcp.html
+++ b/radar/content/tools/playwright-mcp.html
@@ -1,0 +1,45 @@
+---
+name: "Playwright MCP"
+ring: "Hold"
+isNew: "TRUE"
+status: "New"
+---
+
+<h4>Description:</h4>
+<p>
+  Playwright MCP is Microsoft's Model Context Protocol server for browser automation. It exposes Playwright's browser
+  control as callable functions for AI models, streaming full context back into the conversation on every interaction:
+  accessibility trees, console output, and screenshots. It integrates directly with MCP-compatible clients like
+  Claude Desktop and VS Code Copilot with no filesystem setup required.
+</p>
+
+<h4>Pros:</h4>
+<ul>
+  <li>
+    <strong>Zero friction to get started:</strong> No filesystem dependency. If your tool supports MCP, you can
+    connect it to a browser in minutes.
+  </li>
+  <li>
+    <strong>Works in sandboxed environments:</strong> No shell or filesystem access needed, making it the right
+    choice when agent isolation is a hard requirement.
+  </li>
+</ul>
+
+<h4>Cons:</h4>
+<ul>
+  <li>
+    <strong>High token consumption:</strong> Full accessibility trees stream into the context window on every
+    interaction. A single page snapshot can cost 800 or more tokens, and it adds up fast.
+  </li>
+  <li>
+    <strong>Context pollution over time:</strong> Stale page state accumulates in the conversation. Agents start
+    reasoning from earlier states rather than the current one, leading to fabricated selectors and incorrect actions.
+  </li>
+</ul>
+
+<h4>Conclusion:</h4>
+<p>
+  We put Playwright MCP on Hold. If you are already using it, it is not broken, but we recommend moving to
+  Playwright CLI. The token savings, cleaner context, and better fit with coding agent workflows make it the
+  stronger choice for any serious test automation work.
+</p>


### PR DESCRIPTION
Add two new tool blips covering the AI-driven browser automation space.